### PR TITLE
Added support for more dimensions in `lerp`, `quad_bez`, `cube_bez`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "interpolation"
-version = "0.0.1"
+version = "0.0.2"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,15 +12,14 @@
 //! The choice of interpolation algorithm depends often
 //! on the circumstances where it used.
 
-use std::num::Float;
-
 pub use ease::{
     Ease,
     EaseFunction,
 };
+pub use spatial::Spatial;
 
 mod ease;
-
+mod spatial;
 
 /// Performs linear interpolation.
 /// A linear interpolation consists of two states 'a' and 'b'.
@@ -29,8 +28,8 @@ mod ease;
 /// When 't' is zero then 'a' has full weight.
 /// When 't' is one then 'b' has full weight.
 #[inline(always)]
-pub fn lerp<T: Copy + Float>(a: T, b: T, t: T) -> T {
-    a + (b - a) * t
+pub fn lerp<T: Spatial>(a: &T, b: &T, t: &<T as Spatial>::Scalar) -> T {
+    a.add(&b.sub(a).scale(t))
 }
 
 /// Performs quadratic beziér interpolation.
@@ -39,15 +38,15 @@ pub fn lerp<T: Copy + Float>(a: T, b: T, t: T) -> T {
 ///
 /// <a href="http://en.wikipedia.org/wiki/B%C3%A9zier_curve">Beziér Curve at Wikipedia</a>
 #[inline(always)]
-pub fn quad_bez<T: Copy + Float>(
-    x0: T,
-    x1: T,
-    x2: T,
-    t: T
+pub fn quad_bez<T: Spatial>(
+    x0: &T,
+    x1: &T,
+    x2: &T,
+    t: &<T as Spatial>::Scalar
 ) -> T {
     let x_0_1 = lerp(x0, x1, t);
     let x_1_2 = lerp(x1, x2, t);
-    lerp(x_0_1, x_1_2, t)
+    lerp(&x_0_1, &x_1_2, t)
 }
 
 /// Performs cubic beziér interpolation.
@@ -56,15 +55,14 @@ pub fn quad_bez<T: Copy + Float>(
 ///
 /// <a href="http://en.wikipedia.org/wiki/B%C3%A9zier_curve">Beziér Curve at Wikipedia</a>
 #[inline(always)]
-pub fn cub_bez<T: Copy + Float>(
-    x0: T,
-    x1: T,
-    x2: T,
-    x3: T,
-    t: T
+pub fn cub_bez<T: Spatial>(
+    x0: &T,
+    x1: &T,
+    x2: &T,
+    x3: &T,
+    t: &<T as Spatial>::Scalar
 ) -> T {
     let x_0_2 = quad_bez(x0, x1, x2, t);
     let x_1_3 = quad_bez(x1, x2, x3, t);
-    lerp(x_0_2, x_1_3, t)
+    lerp(&x_0_2, &x_1_3, t)
 }
-

--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -1,0 +1,140 @@
+//! A trait to allow interpolation over spatial structures.
+
+use std::num::Float;
+
+/// Used for interpolation over spatial structures.
+pub trait Spatial {
+    /// The scalar type.
+    type Scalar;
+
+    /// Add
+    fn add(&self, other: &Self) -> Self;
+    /// Subtract
+    fn sub(&self, other: &Self) -> Self;
+    /// Scales with a scalar.
+    fn scale(&self, scalar: &<Self as Spatial>::Scalar) -> Self;
+}
+
+impl<T> Spatial for T
+    where
+        T: Float
+{
+    type Scalar = T;
+
+    #[inline(always)]
+    fn add(&self, other: &Self) -> Self {
+        *self + *other
+    }
+
+    #[inline(always)]
+    fn sub(&self, other: &Self) -> Self {
+        *self - *other
+    }
+
+    #[inline(always)]
+    fn scale(&self, other: &<Self as Spatial>::Scalar) -> Self {
+        *self * *other
+    }
+}
+
+impl<T> Spatial for [T; 2]
+    where
+        T: Spatial
+{
+    type Scalar = <T as Spatial>::Scalar;
+
+    #[inline(always)]
+    fn add(&self, other: &Self) -> Self {
+        [
+            self[0].add(&other[0]),
+            self[1].add(&other[1])
+        ]
+    }
+
+    #[inline(always)]
+    fn sub(&self, other: &Self) -> Self {
+        [
+            self[0].sub(&other[0]),
+            self[1].sub(&other[1])
+        ]
+    }
+
+    #[inline(always)]
+    fn scale(&self, scalar: &<Self as Spatial>::Scalar) -> Self {
+        [
+            self[0].scale(scalar),
+            self[1].scale(scalar),
+        ]
+    }
+}
+
+impl<T> Spatial for [T; 3]
+    where
+        T: Spatial
+{
+    type Scalar = <T as Spatial>::Scalar;
+
+    #[inline(always)]
+    fn add(&self, other: &Self) -> Self {
+        [
+            self[0].add(&other[0]),
+            self[1].add(&other[1]),
+            self[2].add(&other[2])
+        ]
+    }
+
+    #[inline(always)]
+    fn sub(&self, other: &Self) -> Self {
+        [
+            self[0].sub(&other[0]),
+            self[1].sub(&other[1]),
+            self[2].sub(&other[2])
+        ]
+    }
+
+    #[inline(always)]
+    fn scale(&self, scalar: &<Self as Spatial>::Scalar) -> Self {
+        [
+            self[0].scale(scalar),
+            self[1].scale(scalar),
+            self[2].scale(scalar)
+        ]
+    }
+}
+
+impl<T> Spatial for [T; 4]
+    where
+        T: Spatial
+{
+    type Scalar = <T as Spatial>::Scalar;
+
+    #[inline(always)]
+    fn add(&self, other: &Self) -> Self {
+        [
+            self[0].add(&other[0]),
+            self[1].add(&other[1]),
+            self[2].add(&other[2]),
+            self[3].add(&other[3])
+        ]
+    }
+
+    #[inline(always)]
+    fn sub(&self, other: &Self) -> Self {
+        [
+            self[0].sub(&other[0]),
+            self[1].sub(&other[1]),
+            self[2].sub(&other[2]),
+            self[3].sub(&other[3])
+        ]
+    }
+
+    #[inline(always)]
+    fn scale(&self, scalar: &<Self as Spatial>::Scalar) -> Self {
+        [
+            self[0].scale(scalar),
+            self[1].scale(scalar),
+            self[2].scale(scalar),
+            self[3].scale(scalar)
+        ]
+    }
+}


### PR DESCRIPTION
This is a breaking change. To fix the code, insert `&` to pass by
reference.

Closes https://github.com/PistonDevelopers/interpolation/issues/24
